### PR TITLE
upStream 제거

### DIFF
--- a/ui_sample/Assets/exam10_uirx_drag/exam10_uirx_drag.cs
+++ b/ui_sample/Assets/exam10_uirx_drag/exam10_uirx_drag.cs
@@ -16,84 +16,31 @@ public class exam10_uirx_drag : MonoBehaviour {
 				Input.mousePosition - this.transform.position
 			))
 			.DistinctUntilChanged () // remove duplicates
-			.Subscribe (isHover => this.GetComponent<Image> ().color = 
+			.Subscribe (isHover => this.GetComponent<Image> ().color =
 				isHover ? Color.red : Color.green
 		);
 
 		/* Drag and Drop */
-		var downStream = Observable.EveryUpdate()//.UpdateAsObservable ()
-			//.Where (_ => Input.GetMouseButton (0))
-			.Select (_ => Input.GetMouseButton(0))
-			.Where (x => x)
-			//.DistinctUntilChanged()
-			.Select (_ => {
-				//Debug.Log("down start! : " + Time.realtimeSinceStartup);
-				Debug.Log( " downstream " + (Input.mousePosition - this.transform.position).ToString() + " : " + Time.realtimeSinceStartup);
-				return Input.mousePosition - this.transform.position;
-			});
-
-		/*IObservable<Vector3> down_stream = Observable.EveryUpdate()
-			.Select (_ => Input.GetMouseButton(0))
-			.Where (x => x)
-			.DistinctUntilChanged()
-			.Select (_ => {
-				//Debug.Log("down");
-				Vector3 pos = Input.mousePosition - this.transform.position;
-				//Debug.Log( "down " + Input.mousePosition.ToString());
-				Debug.Log( "down pos" + this.transform.position.ToString());
-				return pos;
-				//Vector3 pos = Input.mousePosition;
-				//Vector3[] ar = { Input.mousePosition, gameObject.GetComponent<RectTransform> ().position };
-				//return ar;
-			});
-			*/
-
-
+		var downStream = this.UpdateAsObservable ()
+			.Where (_ => Input.GetMouseButtonDown (0)) /* when mouse down capture delta position */
+			.Select (_ => Input.mousePosition - this.transform.position)
+			.Do (_ => Debug.Log ( "mouseDown" + _));
 
 		/* capture position stream */
-		var moveStream =  Observable.EveryUpdate()//this.UpdateAsObservable ()
+		var moveStream = this.UpdateAsObservable ()
 			.Where (_ => Input.GetMouseButton (0)) /* anyway */
-			//.Select (_ => Input.mousePosition)     /* but, capture mousePosition only */
-			.Select(_=> {
-				//Debug.Log("down moving  : " + Time.realtimeSinceStartup);
-				//Debug.Log( (Input.mousePosition - this.transform.position).ToString() + " : " + Time.realtimeSinceStartup);
-				//Debug.Log( "move : " + this.transform.position.ToString());
-				//Debug.Log( "move" + Input.mousePosition.ToString());
-				return Input.mousePosition;
-			})
-			.DistinctUntilChanged ();
-
-		/* only once triggered, doesn't need distinct */
-//		var upStream =  Observable.EveryUpdate()//this.UpdateAsObservable ()
-//			.Where (_ => Input.GetMouseButtonUp (0)); /* when mouse move */
-
-		IObservable<long> up_stream = Observable.EveryUpdate ()
-			.Where (_ => {
-				if(gameObject.GetComponent<RectTransform>().rect.Contains(Input.mousePosition - this.transform.position)) {
-					return !Input.GetMouseButton (0);
-				}
-				return true;
-			});
-
+			.Select (_ => Input.mousePosition)     /* but, mousePosition only */
+			.DistinctUntilChanged ()
+			.Do (_ => Debug.Log ( "mouseMove" + _));
+		
 		Observable.CombineLatest<Vector3> (downStream, moveStream)
-			//.Select (_ => _[1]-_[0])
-			.Select (_ => {
-//				Debug.Log( "down pos 2" + this.transform.position.ToString());
-//				Debug.Log( "move" +  _[1].ToString());
-//				Debug.Log( "down 1" + _[0].ToString());
-				//Debug.Log( "down 2" + (Input.mousePosition - this.transform.position).ToString() );
-
-				Debug.Log( " combine " + (  Input.mousePosition - this.transform.position).ToString() + " : " + Time.realtimeSinceStartup);
-
-				return _[1]-_[0];
-			})
-			.TakeUntil (up_stream)
-			.Repeat ()
-			.Subscribe (position => this.transform.position = position);
+			.Select (_ => _[1]-_[0])
+			.Subscribe (position => this.transform.position = position)
+			.AddTo(this.gameObject); /* add to disposable */
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+
 	}
 }


### PR DESCRIPTION
Unity에선 mouse 좌표와 버튼의 상태를 따로 관리하고 CombineLatest는 조합하는 Stream이 모두 존재할 때만 Observable 하므로 mouseup 인 상태에선 Stream이 발생하지 않습니다.
따라서 mouseUp에 대한 TakeWhile과 Repeat역시 불필요하네요.
디버깅을 위해 .Do를 넣었습니다. .Do는 Subscribe 를 가짜로 발생시켜서 값을 볼 수 있는 유용한 도구더군요.
